### PR TITLE
#12 - h2-console  옵션 삭제

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,9 @@ spring:
     username: admin
     password: rlawldnjs1234!
     driver-class-name: com.mysql.cj.jdbc.Driver
+  #  url: jdbc:h2:mem:testdb
+  #  username: sa
+  #  driver-class-name: org.h2.Driver
   jpa:
     defer-datasource-initialization: true
     hibernate.ddl-auto: create
@@ -20,7 +23,6 @@ spring:
     properties:
       hibernate.format_sql: true
       hibernate.default_batch_fetch_size: 100
-  h2.console.enabled: false
   sql.init.mode: always
   # thymeleaf.cache: false
 


### PR DESCRIPTION
h2는 테스트 전용으로 만 사용하고 , 서비스 단계에서
따로 사용하지 않을 것이므로 콘솔도 불필요.